### PR TITLE
feat: Pull and display data from GH gist

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -6,5 +6,14 @@
 
 module.exports = {
   siteName: 'Gridsome',
-  plugins: []
+  plugins: [],
+  templates: {
+    CardPost: [
+      {
+        path: (node) => {
+          return `/card/${node.path}`
+        }
+      }
+    ]
+  }
 }

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -5,12 +5,32 @@
 // Changes here require a server restart.
 // To restart press CTRL + C in terminal and run `gridsome develop`
 
-module.exports = function (api) {
+const axios = require("axios");
+
+module.exports = function(api) {
   api.loadSource(({ addCollection }) => {
     // Use the Data Store API here: https://gridsome.org/docs/data-store-api/
-  })
+  });
 
   api.createPages(({ createPage }) => {
     // Use the Pages API here: https://gridsome.org/docs/pages-api/
-  })
-}
+  });
+
+  api.loadSource(async (actions) => {
+    const { data: cards } = await axios.get(
+      "https://gist.githubusercontent.com/novellac/029844c63ceed954e5c508b593c06e51/raw/cdc5bf3bb1ca7a59ba857601bc94dcf4ecd1da8a/allCards.json"
+    );
+
+    const collection = actions.addCollection({
+      typeName: "CardPost",
+    });
+
+    for (const card of cards.data) {
+      collection.addNode({
+        path: card.path,
+        havers: card.havers,
+        wishers: card.wishers,
+      });
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "gridsome build"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "gridsome": "^0.7.0"
   }
 }

--- a/src/templates/CardPost.vue
+++ b/src/templates/CardPost.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <h1>Happy birthday, {{ haverNames }}!</h1>
+
+    <div v-for="wish in $page.cardPost.wishers" :key="wish.id">
+      <p>{{ wish.message }}</p>
+      <p>~ {{ wish.name }}</p>
+    </div>
+  </div>
+</template>
+
+<page-query>
+query ($id: ID!) {
+  cardPost(id: $id) {
+    havers {
+      id
+      name
+      date
+    }
+    wishers {
+      id
+      name
+      message
+    }
+  }
+}
+</page-query>
+
+<script>
+export default {
+  computed: {
+    haverNames() {
+      const havers = this.$page.cardPost.havers;
+
+      // Supported everywhere except IE
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
+      const lf = new Intl.ListFormat("en");
+
+      let names = havers.map(function(haver) {
+        return haver.name;
+      });
+
+      return lf.format(names);
+    },
+  },
+};
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,6 +1670,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-loader@8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33"
@@ -3855,6 +3862,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.10.0:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.2.tgz#cecb825047c00f5e66b142f90fed4f515dec789b"
+  integrity sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
**Issue**
We don't yet have a way to pull in data from an external source.

**Work done**
This PR 
- Creates a CardPost content type and a template to display CardPost items. 
- Sets up the server.config file to pulls from [Github gist](https://gist.githubusercontent.com/novellac/029844c63ceed954e5c508b593c06e51/raw/cdc5bf3bb1ca7a59ba857601bc94dcf4ecd1da8a/allCards.json) which mocks the data.

**Steps to test**
Check out this branch locally.
In the root of the project, run `yarn` to get the Axios package.
Run `gridsome develop` to spin up the project locally.
Navigate to one of the mocked pages, such as [this one](http://localhost:8080/card/randompath1) or [this one](http://localhost:8080/card/randompath2).
Outcome: You should see card content which we pulled from the Github gist.

**Gotchas**
The API might change... and that's ok! This PR will allow us to pull from any data source which we can fetch with Axios. Later, we can rework the structure of the data it's pulling.
Note that this PR doesn't style or manipulate the data (such as making birthdates, etc). It just does the bare minimum to prove that we can successfully pull in the data.