### PR TITLE
feat: Add fonts and components for text

### DIFF
--- a/src/components/BaseDate.vue
+++ b/src/components/BaseDate.vue
@@ -1,0 +1,10 @@
+<template>
+  <p class="text-lg text-center md:text-2xl xl:text-3xl">
+    <slot />
+  </p>
+</template>
+<script>
+export default {
+  name: 'BaseDate'
+}
+</script>

--- a/src/components/BaseHeader.vue
+++ b/src/components/BaseHeader.vue
@@ -1,0 +1,41 @@
+<template>
+  <component :is="tag" class="text-center font-display" :class="classes">
+    <slot />
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'BaseHeader',
+  props: {
+    level: {
+      type: Number,
+      default: 1
+    },
+  },
+  computed: {
+    tag () {
+      return `h${this.level}`
+    },
+    classes () {
+      let classList = []
+      switch (this.level) {
+        case 1:
+        default:
+          return [
+            'text-5xl',
+            'md:text-7xl',
+            'xl:text-8xl'
+          ]
+
+        case 2:
+          return [
+            'text-xl',
+            'md:text-2xl',
+            'xl:text-3xl'
+          ]
+      }
+    }
+  },
+}
+</script>

--- a/src/components/BaseParagraph.vue
+++ b/src/components/BaseParagraph.vue
@@ -1,0 +1,9 @@
+<template>
+  <p class="text-sm md:text-base">
+    <slot />
+  </p>
+</template>
+export default {
+  name: 'BaseParagraph'
+}
+</script>

--- a/src/components/HeaderOne.vue
+++ b/src/components/HeaderOne.vue
@@ -1,5 +1,0 @@
-<template>
-  <h1 class="text-center text-5xl md:text-7xl xl:text-8xl 2xl:text-9xl">
-    <slot />
-  </h1>
-</template>

--- a/src/main.js
+++ b/src/main.js
@@ -6,4 +6,25 @@ import DefaultLayout from '~/layouts/Default.vue'
 export default function (Vue, { router, head, isClient }) {
   // Set default layout as a global component
   Vue.component('Layout', DefaultLayout)
+
+  head.link.push({
+    rel: 'preconnect',
+    href: 'https://fonts.googleapis.com'
+  })
+
+  head.link.push({
+    rel: 'preconnect',
+    href: 'https://fonts.gstatic.com',
+    crossorigin: true
+  })
+
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap'
+  })
+
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Overlock:wght@700;900&display=swap'
+  })
 }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout class="bg-gray-200">
-    <HeaderOne>Birthday Basher!</HeaderOne>
+    <BaseHeader>Birthday Basher!</BaseHeader>
 
     <p>
       Welcome to the Birthday Basher. Navigate to your special string to see
@@ -43,11 +43,11 @@ query Cardposts {
 </page-query>
 
 <script>
-import HeaderOne from "@/components/HeaderOne.vue";
+import BaseHeader from "@/components/BaseHeader.vue";
 
 export default {
   components: {
-    HeaderOne,
+    BaseHeader,
   },
   metaInfo: {
     title: "Hello, world!",

--- a/src/templates/CardPost.vue
+++ b/src/templates/CardPost.vue
@@ -1,12 +1,12 @@
 <template>
   <Layout>
-    <p class="text-center text-xl md:text-3xl xl:text-4xl">
+    <BaseDate>
       {{ cardDate }}
-    </p>
-    <HeaderOne>Happy birthday, {{ haverNames }}!</HeaderOne>
+    </BaseDate>
+    <BaseHeader>Happy birthday, {{ haverNames }}!</BaseHeader>
     <div v-for="wish in $page.cardPost.wishers" :key="wish.id">
-      <p>{{ wish.message }}</p>
-      <p>~ {{ wish.name }}</p>
+      <BaseParagraph>{{ wish.message }}</BaseParagraph>
+      <BaseHeader :level="2">~ {{ wish.name }}</BaseHeader>
     </div>
   </Layout>
 </template>
@@ -36,39 +36,43 @@ query ($id: ID!) {
 </page-query>
 
 <script>
-import HeaderOne from "@/components/HeaderOne.vue";
+import BaseHeader from '@/components/BaseHeader.vue'
+import BaseParagraph from '@/components/BaseParagraph.vue'
+import BaseDate from '@/components/BaseDate.vue'
 
 export default {
   components: {
-    HeaderOne,
+    BaseDate,
+    BaseHeader,
+    BaseParagraph
   },
   computed: {
-    haverNames() {
-      const havers = this.$page.cardPost.havers;
+    haverNames () {
+      const havers = this.$page.cardPost.havers
 
       // Supported everywhere except IE
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
-      const lf = new Intl.ListFormat("en");
+      const lf = new Intl.ListFormat('en')
 
-      let names = havers.map(function(haver) {
-        return haver.name;
-      });
+      let names = havers.map(function (haver) {
+        return haver.name
+      })
 
-      return lf.format(names);
+      return lf.format(names)
     },
-    cardDate() {
-      const carddate = this.$page.cardPost.carddate;
-      const year = new Date().getFullYear();
-      const date = new Date(`${year}-${carddate.month}-${carddate.day}`);
+    cardDate () {
+      const carddate = this.$page.cardPost.carddate
+      const year = new Date().getFullYear()
+      const date = new Date(`${year}-${carddate.month}-${carddate.day}`)
 
       const options = {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      };
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      }
 
-      return date.toLocaleDateString("en-US", options);
-    },
-  },
-};
+      return date.toLocaleDateString('en-US', options)
+    }
+  }
+}
 </script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,10 @@ module.exports = {
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},
+    fontFamily: {
+      'sans': ["Roboto Mono", 'Aria', 'sans-serif'],
+      'display': ['Overlock']
+    }
   },
   variants: {
     extend: {},


### PR DESCRIPTION
**Work done**
This PR will add fonts for Overlock and Roboto Mono. It also creates several base components to use for controlling standardized text classes.

**Steps to test**
1. Run `gridsome develop`
1. Navigate to a working example link, such as [this one](http://localhost:8080/card/randompath1/).
- See that the text shows with no errors.
- See that, at different breakpoints, the text fontface and size matches [the Figma](https://www.figma.com/file/psy61BmbgR6vpJe40Yu2JD/Birthday-Basher?node-id=63%3A232).